### PR TITLE
feat: Adding initial implementation of photo grid

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -5,7 +5,8 @@ import {
   webLightTheme,
   FluentProvider,
 } from "@fluentui/react-components";
-import { Nav } from "./common";
+import { Nav, PhotoGrid } from "./common";
+import type { PhotoGridItem } from "./common";
 
 const useAppStyles = makeStyles({
   app: {
@@ -13,12 +14,28 @@ const useAppStyles = makeStyles({
   },
 });
 
+/* TODO: Remove this function and replace it with actual photo metadata when we retrieve the images */
+function createPhotoArray(size: number): PhotoGridItem[] {
+  const result: PhotoGridItem[] = [];
+  for (let i = 0; i < size; i++) {
+    const num = Math.random() * 1700000000000;
+    for (let j = 0; j < Math.random() * 9 + 1; j++) {
+      result.push({
+        date: new Date(num),
+        src: "https://fabricweb.azureedge.net/fabric-website/placeholders/300x300.png",
+      });
+    }
+  }
+  return result;
+}
+
 export const App = () => {
   const styles = useAppStyles();
 
   return (
     <FluentProvider className={styles.app} theme={webLightTheme}>
       <Nav />
+      <PhotoGrid photoItems={createPhotoArray(50)} />
     </FluentProvider>
   );
 };

--- a/front-end/src/common/PhotoGrid/PhotoGrid.tsx
+++ b/front-end/src/common/PhotoGrid/PhotoGrid.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { Image, Title3 } from "@fluentui/react-components";
+import { usePhotoGridStyles } from "./usePhotoGridStyles";
+import type { PhotoGridItem, PhotoGridProps } from "./PhotoGrid.types";
+
+const sortPhotos = (a: PhotoGridItem, b: PhotoGridItem): number => {
+  return a.date < b.date ? 1 : -1;
+};
+
+const localeDateOptions: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  weekday: "short",
+  year: "numeric",
+};
+
+export const PhotoGrid: React.FC<PhotoGridProps> = (props) => {
+  const styles = usePhotoGridStyles();
+
+  const photoItems = props.photoItems;
+  photoItems.sort(sortPhotos);
+
+  const renderPhotos = React.useCallback((): React.ReactNode => {
+    const photoGrid: JSX.Element[] = [];
+    let currentSection: JSX.Element[] = [];
+    let currentDate;
+
+    for (const photo of photoItems) {
+      if (currentDate === undefined) {
+        currentDate = photo.date;
+        photoGrid.push(
+          <Title3>
+            {photo.date.toLocaleDateString(undefined, localeDateOptions)}
+          </Title3>
+        );
+      } else if (currentDate.getDate() !== photo.date.getDate()) {
+        currentDate = photo.date;
+        photoGrid.push(
+          <div className={styles.daySection}>{currentSection}</div>
+        );
+        currentSection = [];
+        photoGrid.push(
+          <Title3>
+            {photo.date.toLocaleDateString(undefined, localeDateOptions)}
+          </Title3>
+        );
+      }
+
+      currentSection.push(<Image shadow src={photo.src} />);
+    }
+
+    photoGrid.push(<div className={styles.daySection}>{currentSection}</div>);
+
+    return photoGrid;
+  }, [photoItems, styles.daySection]);
+
+  return <div className={styles.root}>{renderPhotos()}</div>;
+};

--- a/front-end/src/common/PhotoGrid/PhotoGrid.types.ts
+++ b/front-end/src/common/PhotoGrid/PhotoGrid.types.ts
@@ -1,0 +1,8 @@
+export type PhotoGridProps = {
+  photoItems: PhotoGridItem[];
+};
+
+export type PhotoGridItem = {
+  date: Date;
+  src: string;
+};

--- a/front-end/src/common/PhotoGrid/index.ts
+++ b/front-end/src/common/PhotoGrid/index.ts
@@ -1,0 +1,2 @@
+export { PhotoGrid } from "./PhotoGrid";
+export type { PhotoGridItem } from "./PhotoGrid.types";

--- a/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
+++ b/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
@@ -1,0 +1,22 @@
+import { makeStyles, shorthands } from "@fluentui/react-components";
+
+export const usePhotoGridStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    flexWrap: "wrap",
+    ...shorthands.gap("10px"),
+    ...shorthands.padding("30px"),
+  },
+  photo: {
+    backgroundColor: "red",
+    height: "50px",
+    width: "50px",
+  },
+  daySection: {
+    display: "flex",
+    flexWrap: "wrap",
+    ...shorthands.gap("10px"),
+    paddingBottom: "20px",
+  },
+});

--- a/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
+++ b/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
@@ -8,11 +8,6 @@ export const usePhotoGridStyles = makeStyles({
     ...shorthands.gap("10px"),
     ...shorthands.padding("30px"),
   },
-  photo: {
-    backgroundColor: "red",
-    height: "50px",
-    width: "50px",
-  },
   daySection: {
     display: "flex",
     flexWrap: "wrap",

--- a/front-end/src/common/index.ts
+++ b/front-end/src/common/index.ts
@@ -1,1 +1,2 @@
 export * from "./Nav";
+export * from "./PhotoGrid";


### PR DESCRIPTION
This PR adds the initial implementation of the photo grid that will be displayed that will be displayed whenever a user has logged in to at least one photo storage service. This initial implementation is using randomly generated data to create a grid of images and supports grouping per date and sorting the images so that the newest ones come first.

<img width="1879" alt="image" src="https://user-images.githubusercontent.com/7798177/191366473-6e270287-a0c2-4d4d-8a38-86dbf1daa759.png">
