### PR TITLE
feat: Adding initial side nav implementation

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -5,7 +5,7 @@ import {
   webLightTheme,
   FluentProvider,
 } from "@fluentui/react-components";
-import { Nav, PhotoGrid } from "./common";
+import { Nav, PhotoGrid, SideNav } from "./common";
 import type { PhotoGridItem } from "./common";
 
 const useAppStyles = makeStyles({
@@ -35,6 +35,7 @@ export const App = () => {
   return (
     <FluentProvider className={styles.app} theme={webLightTheme}>
       <Nav />
+      <SideNav />
       <PhotoGrid photoItems={createPhotoArray(50)} />
     </FluentProvider>
   );

--- a/front-end/src/common/SideNav/SideNav.tsx
+++ b/front-end/src/common/SideNav/SideNav.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Tab, TabList } from "@fluentui/react-components";
+import {
+  CollectionsRegular,
+  ImageMultipleRegular,
+} from "@fluentui/react-icons";
+import { useSideNavStyles } from "./useSideNavStyles";
+
+export const SideNav: React.FC<{}> = () => {
+  const styles = useSideNavStyles();
+
+  return (
+    <div className={styles.root}>
+      <TabList appearance="subtle" defaultSelectedValue="photos" vertical>
+        <Tab
+          className={styles.tab}
+          content={{ className: styles.tabContent }}
+          icon={{
+            className: styles.tabIcon,
+            children: <ImageMultipleRegular />,
+          }}
+          value="photos"
+        >
+          Photos
+        </Tab>
+        <Tab
+          className={styles.tab}
+          content={{ className: styles.tabContent }}
+          icon={{ className: styles.tabIcon, children: <CollectionsRegular /> }}
+          value="albums"
+        >
+          Albums
+        </Tab>
+      </TabList>
+    </div>
+  );
+};

--- a/front-end/src/common/SideNav/index.ts
+++ b/front-end/src/common/SideNav/index.ts
@@ -1,0 +1,1 @@
+export * from "./SideNav";

--- a/front-end/src/common/SideNav/useSideNavStyles.tsx
+++ b/front-end/src/common/SideNav/useSideNavStyles.tsx
@@ -1,0 +1,24 @@
+import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
+
+export const useSideNavStyles = makeStyles({
+  root: {
+    boxShadow: `0px 4px 8px ${tokens.colorBrandShadowAmbient}, 0 14px 28px ${tokens.colorNeutralStroke1}`,
+    float: "left",
+    height: "calc(100vh - 120px)",
+    position: "sticky",
+    ...shorthands.padding("30px", "10px"),
+    top: "60px",
+    width: "250px",
+  },
+  tab: {
+    columnGap: tokens.spacingHorizontalL,
+  },
+  tabContent: {
+    fontSize: tokens.fontSizeBase400,
+  },
+  tabIcon: {
+    fontSize: tokens.fontSizeBase600,
+    height: "28px",
+    width: "28px",
+  },
+});

--- a/front-end/src/common/index.ts
+++ b/front-end/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from "./Nav";
 export * from "./PhotoGrid";
+export * from "./SideNav";


### PR DESCRIPTION
This PR adds an initial side navigation bar implementation that includes tabs for `Photos` and `Albums`.

<img width="1887" alt="image" src="https://user-images.githubusercontent.com/7798177/191386508-3f7a05b1-5911-4253-9b99-a06a3cedc376.png">
