### PR TITLE
feat: Adding initial photo carousel

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -3,11 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-<<<<<<< Updated upstream
     "@auth0/auth0-react": "^1.11.0",
-=======
     "@fluentui/keyboard-keys": "^9.0.0",
->>>>>>> Stashed changes
     "@fluentui/react-components": "^9.3.0",
     "@fluentui/react-icons": "^2.0.182",
     "@fluentui/react-portal": "^9.0.5",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -3,9 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+<<<<<<< Updated upstream
     "@auth0/auth0-react": "^1.11.0",
+=======
+    "@fluentui/keyboard-keys": "^9.0.0",
+>>>>>>> Stashed changes
     "@fluentui/react-components": "^9.3.0",
     "@fluentui/react-icons": "^2.0.182",
+    "@fluentui/react-portal": "^9.0.5",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.59",
     "@types/react": "^18.0.20",

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -15,48 +15,22 @@ const useAppStyles = makeStyles({
   },
 });
 
-<<<<<<< Updated upstream
-=======
-/* TODO: Remove this function and replace it with actual photo metadata when we retrieve the images */
-function createPhotoArray(size: number): PhotoGridItem[] {
-  const result: PhotoGridItem[] = [];
-  for (let i = 0; i < size; i++) {
-    const num = Math.random() * 1700000000000;
-    for (let j = 0; j < Math.random() * 9 + 1; j++) {
-      const height = Math.ceil(Math.random() * 900) + 100;
-      const width = Math.ceil(Math.random() * 900) + 100;
-      result.push({
-        date: new Date(num),
-        src: `https://via.placeholder.com/${width}x${height}.png`,
-      });
-    }
-  }
-  return result;
-}
-
->>>>>>> Stashed changes
 export const App = () => {
-  const photos = createPhotoArray(50);
   const styles = useAppStyles();
 
   return (
-<<<<<<< Updated upstream
     <Router>
       <Auth0ProviderWithHistory>
         <FluentProvider className={styles.app} theme={webLightTheme}>
           <Routes>
             <Route path="/" element={<LoginView />} />
-            <Route path="/photos" element={<ProtectedRoute component={PhotosView} />} />
+            <Route
+              path="/photos"
+              element={<ProtectedRoute component={PhotosView} />}
+            />
           </Routes>
         </FluentProvider>
       </Auth0ProviderWithHistory>
     </Router>
-=======
-    <FluentProvider className={styles.app} theme={webLightTheme}>
-      <Nav />
-      <SideNav />
-      <PhotoGrid photoItems={photos} />
-    </FluentProvider>
->>>>>>> Stashed changes
   );
 };

--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -15,10 +15,32 @@ const useAppStyles = makeStyles({
   },
 });
 
+<<<<<<< Updated upstream
+=======
+/* TODO: Remove this function and replace it with actual photo metadata when we retrieve the images */
+function createPhotoArray(size: number): PhotoGridItem[] {
+  const result: PhotoGridItem[] = [];
+  for (let i = 0; i < size; i++) {
+    const num = Math.random() * 1700000000000;
+    for (let j = 0; j < Math.random() * 9 + 1; j++) {
+      const height = Math.ceil(Math.random() * 900) + 100;
+      const width = Math.ceil(Math.random() * 900) + 100;
+      result.push({
+        date: new Date(num),
+        src: `https://via.placeholder.com/${width}x${height}.png`,
+      });
+    }
+  }
+  return result;
+}
+
+>>>>>>> Stashed changes
 export const App = () => {
+  const photos = createPhotoArray(50);
   const styles = useAppStyles();
 
   return (
+<<<<<<< Updated upstream
     <Router>
       <Auth0ProviderWithHistory>
         <FluentProvider className={styles.app} theme={webLightTheme}>
@@ -29,5 +51,12 @@ export const App = () => {
         </FluentProvider>
       </Auth0ProviderWithHistory>
     </Router>
+=======
+    <FluentProvider className={styles.app} theme={webLightTheme}>
+      <Nav />
+      <SideNav />
+      <PhotoGrid photoItems={photos} />
+    </FluentProvider>
+>>>>>>> Stashed changes
   );
 };

--- a/front-end/src/common/Nav/useNavStyles.ts
+++ b/front-end/src/common/Nav/useNavStyles.ts
@@ -5,6 +5,7 @@ export const useNavStyles = makeStyles({
     alignItems: "center",
     backgroundColor: "inherit",
     boxShadow: `0 0 8px ${tokens.colorBrandShadowAmbient}, 0 14px 28px ${tokens.colorNeutralStroke1}`,
+    boxSizing: "border-box",
     display: "flex",
     justifyContent: "end",
     minHeight: "60px",

--- a/front-end/src/common/PhotoCarousel/PhotoCarousel.tsx
+++ b/front-end/src/common/PhotoCarousel/PhotoCarousel.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { Button, Image } from "@fluentui/react-components";
+import { DismissRegular } from "@fluentui/react-icons";
+import { Portal } from "@fluentui/react-portal";
+import { usePhotoCarouselStyles } from "./usePhotoCarouselStyles";
+import type { PhotoCarouselProps } from "./PhotoCarousel.types";
+
+export const PhotoCarousel: React.FC<PhotoCarouselProps> = (props) => {
+  const styles = usePhotoCarouselStyles();
+
+  const { src, togglePhotoCarousel } = props;
+
+  return (
+    <Portal>
+      <div className={styles.backdrop}></div>
+      <div className={styles.photoContainer}>
+        <Image className={styles.photo} fit="contain" src={src} />
+      </div>
+      <Button
+        appearance="transparent"
+        className={styles.closeButton}
+        icon={<DismissRegular />}
+        onClick={togglePhotoCarousel}
+        shape="circular"
+        size="large"
+      />
+    </Portal>
+  );
+};

--- a/front-end/src/common/PhotoCarousel/PhotoCarousel.types.ts
+++ b/front-end/src/common/PhotoCarousel/PhotoCarousel.types.ts
@@ -1,0 +1,10 @@
+import React from "react";
+
+export type PhotoCarouselProps = {
+  src: string;
+  togglePhotoCarousel: (
+    ev?:
+      | React.MouseEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLImageElement>
+  ) => void;
+};

--- a/front-end/src/common/PhotoCarousel/index.ts
+++ b/front-end/src/common/PhotoCarousel/index.ts
@@ -1,0 +1,1 @@
+export { PhotoCarousel } from "./PhotoCarousel";

--- a/front-end/src/common/PhotoCarousel/usePhotoCarouselStyles.ts
+++ b/front-end/src/common/PhotoCarousel/usePhotoCarouselStyles.ts
@@ -1,0 +1,43 @@
+import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
+
+export const usePhotoCarouselStyles = makeStyles({
+  backdrop: {
+    backgroundColor: tokens.colorNeutralBackgroundInverted,
+    display: "flex",
+    height: "100vh",
+    opacity: 0.85,
+    overscrollBehaviorY: "contain",
+    position: "fixed",
+    top: 0,
+    userSelect: "none",
+    width: "100vw",
+  },
+  photoContainer: {
+    display: "grid",
+    height: "100vh",
+    position: "fixed",
+    top: 0,
+    width: "100vw",
+  },
+  photo: {
+    ...shorthands.margin("auto"),
+    maxHeight: "100vh",
+    maxWidth: "100%",
+  },
+  closeButton: {
+    color: tokens.colorNeutralForegroundInverted,
+    position: "fixed",
+    right: "10px",
+    top: "10px",
+
+    ":hover": {
+      backgroundColor: tokens.colorNeutralForeground2,
+      color: tokens.colorNeutralForegroundInvertedHover,
+    },
+
+    ":hover:active": {
+      backgroundColor: tokens.colorNeutralForeground2Pressed,
+      color: tokens.colorNeutralForegroundInvertedPressed,
+    },
+  },
+});

--- a/front-end/src/common/PhotoGrid/PhotoGrid.tsx
+++ b/front-end/src/common/PhotoGrid/PhotoGrid.tsx
@@ -25,7 +25,6 @@ export const PhotoGrid: React.FC<PhotoGridProps> = (props) => {
   const [showPhotoCarousel, setShowPhotoCarousel] = React.useState(false);
 
   const onEscapePhotoCarousel = React.useCallback((ev: KeyboardEvent) => {
-    console.log("hehe");
     if (ev.key === Escape) {
       setShowPhotoCarousel(false);
       window.removeEventListener("keydown", onEscapePhotoCarousel);

--- a/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
+++ b/front-end/src/common/PhotoGrid/usePhotoGridStyles.tsx
@@ -2,16 +2,33 @@ import { makeStyles, shorthands } from "@fluentui/react-components";
 
 export const usePhotoGridStyles = makeStyles({
   root: {
+    boxSizing: "border-box",
     display: "flex",
     flexDirection: "column",
     flexWrap: "wrap",
     ...shorthands.gap("10px"),
+    marginLeft: "250px",
     ...shorthands.padding("30px"),
+    width: "calc(100% - 250px)",
   },
   daySection: {
     display: "flex",
     flexWrap: "wrap",
     ...shorthands.gap("10px"),
     paddingBottom: "20px",
+    overflowX: "hidden",
+    width: "100%",
+
+    "::after": {
+      content: "''",
+      flexGrow: 999999999,
+      height: 0,
+      minWidth: "200px",
+    },
+  },
+  photo: {
+    cursor: "pointer",
+    flexGrow: 1,
+    height: "200px",
   },
 });

--- a/front-end/src/common/SideNav/SideNav.tsx
+++ b/front-end/src/common/SideNav/SideNav.tsx
@@ -11,7 +11,12 @@ export const SideNav: React.FC<{}> = () => {
 
   return (
     <div className={styles.root}>
-      <TabList appearance="subtle" defaultSelectedValue="photos" vertical>
+      <TabList
+        appearance="subtle"
+        defaultSelectedValue="photos"
+        onTabSelect={(ev, data) => alert(data.value)}
+        vertical
+      >
         <Tab
           className={styles.tab}
           content={{ className: styles.tabContent }}

--- a/front-end/src/common/SideNav/useSideNavStyles.tsx
+++ b/front-end/src/common/SideNav/useSideNavStyles.tsx
@@ -3,9 +3,9 @@ import { makeStyles, shorthands, tokens } from "@fluentui/react-components";
 export const useSideNavStyles = makeStyles({
   root: {
     boxShadow: `0px 4px 8px ${tokens.colorBrandShadowAmbient}, 0 14px 28px ${tokens.colorNeutralStroke1}`,
-    float: "left",
-    height: "calc(100vh - 120px)",
-    position: "sticky",
+    boxSizing: "border-box",
+    height: "calc(100vh - 60px)",
+    position: "fixed",
     ...shorthands.padding("30px", "10px"),
     top: "60px",
     width: "250px",

--- a/front-end/src/common/index.ts
+++ b/front-end/src/common/index.ts
@@ -1,4 +1,5 @@
 export * from "./Login";
 export * from "./Nav";
+export * from "./PhotoCarousel";
 export * from "./PhotoGrid";
 export * from "./SideNav";

--- a/front-end/src/views/PhotosView/PhotosView.tsx
+++ b/front-end/src/views/PhotosView/PhotosView.tsx
@@ -7,9 +7,11 @@ function createPhotoArray(size: number): PhotoGridItem[] {
   for (let i = 0; i < size; i++) {
     const num = Math.random() * 1700000000000;
     for (let j = 0; j < Math.random() * 9 + 1; j++) {
+      const height = Math.ceil(Math.random() * 900) + 100;
+      const width = Math.ceil(Math.random() * 900) + 100;
       result.push({
         date: new Date(num),
-        src: "https://fabricweb.azureedge.net/fabric-website/placeholders/300x300.png",
+        src: `https://via.placeholder.com/${width}x${height}.png`,
       });
     }
   }
@@ -17,11 +19,13 @@ function createPhotoArray(size: number): PhotoGridItem[] {
 }
 
 export const PhotosView = () => {
+  const photos = createPhotoArray(50);
+
   return (
     <div>
       <Nav />
       <SideNav />
-      <PhotoGrid photoItems={createPhotoArray(50)} />
+      <PhotoGrid photoItems={photos} />
     </div>
   );
-}
+};


### PR DESCRIPTION
This PR adds the initial implementation of a photo gallery carousel that appears when clicking on a photo. It displays the photo full screen with a black semi-transparent backdrop covering what's behind and preventing clicks and interactions with the content behind the backdrop. You can go back to the photo view by clicking on a close button on the top right or by pressing the Escape key.

Further improvements that are not included in this PR:
- The ability to go to the previous and next photos by pressing the arrow keys/clicking on the far left and right sides of the page when in this mode.
- Adding an animation so the opening of the image seems smooth.