### PR TITLE
feat: Added classes for performing authentication in the back-end

### DIFF
--- a/back-end/ProjectPlatinumShakeWebAPI/Auth/Auth0Authenticator.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/Auth/Auth0Authenticator.cs
@@ -1,0 +1,106 @@
+﻿namespace ProjectPlatinumShakeWebAPI.Auth
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IdentityModel.Tokens.Jwt;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Security.Claims;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.IdentityModel.Protocols;
+    using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+    using Microsoft.IdentityModel.Tokens;
+
+    /// <summary>
+    /// Class meant to be used as a singleton for authenticating JWT tokens for Auth0.
+    /// Code based on "https://github.com/StephenClearyExamples/FunctionsAuth0".
+    /// </summary>
+    public class Auth0Authenticator
+    {
+        private readonly TokenValidationParameters _parameters;
+        private readonly ConfigurationManager<OpenIdConnectConfiguration> _manager;
+        private readonly JwtSecurityTokenHandler _handler;
+
+        /// <summary>
+        /// Creates a new authenticator. In most cases, you should only have one authenticator instance in your application.
+        /// </summary>
+        /// <param name="auth0Domain">The domain of the Auth0 account, e.g., <c>"myauth0test.auth0.com"</c>.</param>
+        /// <param name="audiences">The valid audiences for tokens. This must include the "audience" of the access_token request, and may also include a "client id" to enable id_tokens from clients you own.</param>
+        public Auth0Authenticator(string auth0Domain, IEnumerable<string> audiences)
+        {
+            _parameters = new TokenValidationParameters
+            {
+                ValidIssuer = $"https://{auth0Domain}/",
+                ValidAudiences = audiences.ToArray(),
+                ValidateIssuerSigningKey = true,
+            };
+            _manager = new ConfigurationManager<OpenIdConnectConfiguration>($"https://{auth0Domain}/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+            _handler = new JwtSecurityTokenHandler();
+        }
+
+        /// <summary>
+        /// Creates a new authenticator. In most cases, you should only have one authenticator instance in your application.
+        /// </summary>
+        /// <param name="auth0Domain">The domain of the Auth0 account, e.g., <c>"myauth0test.auth0.com"</c>.</param>
+        /// <param name="audience">A single valid audience for tokens.</param>
+        public Auth0Authenticator(string auth0Domain, string audience) : this(auth0Domain, new string[] {audience} ) { }
+
+        /// <summary>
+        /// Authenticates the user token. Returns a user principal containing claims from the token and a token that can be used to perform actions on behalf of the user.
+        /// Throws an exception if the token fails to authenticate.
+        /// This method has an asynchronous signature, but usually completes synchronously.
+        /// </summary>
+        /// <param name="token">The token, in JWT format.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        public async Task<(ClaimsPrincipal User, SecurityToken ValidatedToken)> AuthenticateAsync(string token, CancellationToken cancellationToken = new CancellationToken())
+        {
+            // Note: ConfigurationManager<T> has an automatic refresh interval of 1 day.
+            //   The config is cached in-between refreshes, so this "asynchronous" call actually completes synchronously unless it needs to refresh.
+            var config = await _manager.GetConfigurationAsync(cancellationToken).ConfigureAwait(false);
+            _parameters.IssuerSigningKeys = config.SigningKeys;
+            var user = _handler.ValidateToken(token, _parameters, out var validatedToken);
+            return (user, validatedToken);
+        }
+
+        /// <summary>
+        /// Authenticates the user via an "Authentication: Bearer {token}" header.
+        /// Returns a user principal containing claims from the token and a token that can be used to perform actions on behalf of the user.
+        /// Throws an exception if the token fails to authenticate or if the Authentication header is malformed.
+        /// This method has an asynchronous signature, but usually completes synchronously.
+        /// </summary>
+        /// <param name="this">The authenticator instance.</param>
+        /// <param name="header">The authentication header.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        public async Task<(ClaimsPrincipal User, SecurityToken ValidatedToken)> AuthenticateAsync(AuthenticationHeaderValue header,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            if (header == null || !string.Equals(header.Scheme, "Bearer", StringComparison.InvariantCultureIgnoreCase))
+                throw new InvalidOperationException("Authentication header does not use Bearer token.");
+            return await this.AuthenticateAsync(header.Parameter, cancellationToken);
+        }
+
+        /// <summary>
+        /// Authenticates the user via an "Authentication: Bearer {token}" header in an HTTP request message.
+        /// Returns a user principal containing claims from the token and a token that can be used to perform actions on behalf of the user.
+        /// Throws an exception if the token fails to authenticate or if the Authentication header is missing or malformed.
+        /// This method has an asynchronous signature, but usually completes synchronously.
+        /// </summary>
+        /// <param name="this">The authenticator instance.</param>
+        /// <param name="request">The HTTP request.</param>
+        /// <param name="cancellationToken">An optional cancellation token.</param>
+        public async Task<(ClaimsPrincipal User, SecurityToken ValidatedToken)> AuthenticateAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken = new CancellationToken())
+        {
+            try
+            {
+                return await this.AuthenticateAsync(request.Headers.Authorization, cancellationToken);
+            }
+            catch (Exception e)
+            {
+                throw new AuthExpectedException("Authentication failed", e);
+            }
+        }
+    }
+}

--- a/back-end/ProjectPlatinumShakeWebAPI/Auth/Auth0Settings.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/Auth/Auth0Settings.cs
@@ -1,0 +1,11 @@
+﻿namespace ProjectPlatinumShakeWebAPI.Auth
+{
+    using System;
+
+    public class Auth0Settings
+    {
+        public static readonly string Auth0Domain = Environment.GetEnvironmentVariable("AUTH0_DOMAIN_URL");
+
+        public static readonly string Auth0Audience = Environment.GetEnvironmentVariable("AUTH0_AUDIENCE");
+    }
+}

--- a/back-end/ProjectPlatinumShakeWebAPI/Auth/AuthExpectedException.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/Auth/AuthExpectedException.cs
@@ -1,0 +1,25 @@
+﻿namespace ProjectPlatinumShakeWebAPI.Auth
+{
+    using System;
+    using System.Net.Http.Headers;
+    using System.Net.Http;
+    using System.Net;
+    using ProjectPlatinumShakeWebAPI.Common;
+
+    /// <summary>
+    /// Class that represents the expected exception to throw for authentication issues.
+    /// Code based on "https://github.com/StephenClearyExamples/FunctionsAuth0".
+    /// </summary>
+    public class AuthExpectedException : ExpectedException
+    {
+        public AuthExpectedException(string message = "", Exception innerException = null)
+            : base(HttpStatusCode.Forbidden, message, innerException)
+        {
+        }
+
+        protected override void ApplyResponseDetails(HttpResponseMessage response)
+        {
+            response.Headers.WwwAuthenticate.Add(new AuthenticationHeaderValue("Bearer", "token_type=\"JWT\""));
+        }
+    }
+}

--- a/back-end/ProjectPlatinumShakeWebAPI/Common/ExpectedException.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/Common/ExpectedException.cs
@@ -1,0 +1,32 @@
+﻿namespace ProjectPlatinumShakeWebAPI.Common
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+
+    /// <summary>
+    /// Represents an exception that is expected to be thrown under specific scenarios.
+    /// The content of this exception may be used to generate a proper HTTP response, instead of an Internal
+    /// Server Error (500) response, which is normally returned for unhandled exceptions.
+    /// Code based on "https://github.com/StephenClearyExamples/FunctionsAuth0".
+    /// </summary>
+    public class ExpectedException : Exception
+    {
+        public HttpStatusCode Code { get; }
+        
+        public ExpectedException(HttpStatusCode code, string message = "", Exception innerException = null)
+            : base(message, innerException)
+        {
+            Code = code;
+        }
+
+        public HttpResponseMessage CreateErrorResponseMessage(HttpRequestMessage request)
+        {
+            var result = request.CreateErrorResponse(Code, Message);
+            ApplyResponseDetails(result);
+            return result;
+        }
+
+        protected virtual void ApplyResponseDetails(HttpResponseMessage response) { }
+    }
+}

--- a/back-end/ProjectPlatinumShakeWebAPI/HttpExample.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/HttpExample.cs
@@ -22,7 +22,7 @@ namespace ProjectPlatinumShakeWebAPI
         }
 
         [FunctionName("Auth")]
-        public async Task<HttpResponseMessage> Hello(
+        public async Task<HttpResponseMessage> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "auth")] HttpRequestMessage req,
             ILogger log)
         {

--- a/back-end/ProjectPlatinumShakeWebAPI/ProjectPlatinumShakeWebAPI.csproj
+++ b/back-end/ProjectPlatinumShakeWebAPI/ProjectPlatinumShakeWebAPI.csproj
@@ -2,8 +2,14 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.23.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.23.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>

--- a/back-end/ProjectPlatinumShakeWebAPI/Startup.cs
+++ b/back-end/ProjectPlatinumShakeWebAPI/Startup.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using ProjectPlatinumShakeWebAPI.Auth;
+
+[assembly: FunctionsStartup(typeof(ProjectPlatinumShakeWebAPI.Startup))]
+
+namespace ProjectPlatinumShakeWebAPI
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            var auth0Authenticator = new Auth0Authenticator(Auth0Settings.Auth0Domain, Auth0Settings.Auth0Audience);
+            builder.Services.AddSingleton(auth0Authenticator);
+        }
+    }
+}

--- a/front-end/.env
+++ b/front-end/.env
@@ -1,2 +1,3 @@
 REACT_APP_AUTH0_DOMAIN="dev-x2l58j05.us.auth0.com"
 REACT_APP_AUTH0_CLIENT_ID="Uaxi8D7UG9meoiQ0SzU9I1S0Zw7KLQkE"
+REACT_APP_AUTH0_AUDIENCE="https://projectplatinumshakewebapi.azurewebsites.net/"

--- a/front-end/src/auth/Auth0ProviderWithHistory.tsx
+++ b/front-end/src/auth/Auth0ProviderWithHistory.tsx
@@ -5,6 +5,7 @@ import { Auth0Provider } from '@auth0/auth0-react';
 export const Auth0ProviderWithHistory : React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   const domain = process.env.REACT_APP_AUTH0_DOMAIN;
   const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID;
+  const audience = process.env.REACT_APP_AUTH0_AUDIENCE;
 
   const navigate = useNavigate();
 
@@ -18,6 +19,7 @@ export const Auth0ProviderWithHistory : React.FC<React.PropsWithChildren<{}>> = 
       clientId={clientId!}
       redirectUri={window.location.origin}
       onRedirectCallback={onRedirectCallback}
+      audience={audience}
     >
       {children}
     </Auth0Provider>


### PR DESCRIPTION
This PR adds a couple of fundamental classes that allow us to create API methods that require authentication in the back-end. Most of the code is based on the following [repository](https://github.com/StephenClearyExamples/FunctionsAuth0). A sample API method using authentication is included for now and it is accessed via the `/api/auth` path (when running locally it would be `localhost:{port}/api/auth`). This method will be deleted a future PR, when I add the real API methods that we want to provide.